### PR TITLE
Use a specific tag version for zookeeper

### DIFF
--- a/mirrors/zookeeper/latest.Dockerfile
+++ b/mirrors/zookeeper/latest.Dockerfile
@@ -1,1 +1,1 @@
-FROM zookeeper:latest
+FROM zookeeper:3.5.9


### PR DESCRIPTION
This is a temporary fix for https://github.com/saltstack/salt/issues/62473

The real fix will be to update docker on the centos 7 host, which I'm also working on in salt-jenkins, but that change can take some time to update the AMI and get the tests to pass. 