### PR TITLE
bump the versions of RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,8 @@ will be commited.
 
 ### [![RabbitMQ](https://github.com/saltstack/salt-ci-containers/actions/workflows/rabbitmq-containers.yml/badge.svg)](https://github.com/saltstack/salt-ci-containers/actions/workflows/rabbitmq-containers.yml)
 
-- [rabbitmq:3.8](https://hub.docker.com/r/_/rabbitmq/tags?name=3.8) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.8`
+- [rabbitmq:3.10](https://hub.docker.com/r/_/rabbitmq/tags?name=3.10) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.10`
+- [rabbitmq:3.11](https://hub.docker.com/r/_/rabbitmq/tags?name=3.11) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.11`
 - [rabbitmq:3.9](https://hub.docker.com/r/_/rabbitmq/tags?name=3.9) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.9`
 
 

--- a/containers.yml
+++ b/containers.yml
@@ -67,8 +67,9 @@ mirrors:
   RabbitMQ:
     container: rabbitmq
     versions:
-      - "3.8"
       - "3.9"
+      - "3.10"
+      - "3.11"
 
   Apache ZooKeeper:
 

--- a/mirrors/rabbitmq/3.10.Dockerfile
+++ b/mirrors/rabbitmq/3.10.Dockerfile
@@ -1,0 +1,1 @@
+FROM rabbitmq:3.10

--- a/mirrors/rabbitmq/3.11.Dockerfile
+++ b/mirrors/rabbitmq/3.11.Dockerfile
@@ -1,0 +1,1 @@
+FROM rabbitmq:3.11

--- a/mirrors/rabbitmq/3.8.Dockerfile
+++ b/mirrors/rabbitmq/3.8.Dockerfile
@@ -1,1 +1,0 @@
-FROM rabbitmq:3.8

--- a/mirrors/rabbitmq/README.md
+++ b/mirrors/rabbitmq/README.md
@@ -1,4 +1,5 @@
 # [![RabbitMQ](https://github.com/saltstack/salt-ci-containers/actions/workflows/rabbitmq-containers.yml/badge.svg)](https://github.com/saltstack/salt-ci-containers/actions/workflows/rabbitmq-containers.yml)
 
-- [rabbitmq:3.8](https://hub.docker.com/r/_/rabbitmq/tags?name=3.8) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.8`
+- [rabbitmq:3.10](https://hub.docker.com/r/_/rabbitmq/tags?name=3.10) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.10`
+- [rabbitmq:3.11](https://hub.docker.com/r/_/rabbitmq/tags?name=3.11) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.11`
 - [rabbitmq:3.9](https://hub.docker.com/r/_/rabbitmq/tags?name=3.9) - `ghcr.io/saltstack/salt-ci-containers/rabbitmq:3.9`


### PR DESCRIPTION
bump the versions of RabbitMQ we are testing again, 3.8 is no longer supported and there is now 3.10 and 3.11.