### PR TITLE
From Salt 3006, there are two additional base dependencies, `packaging` and `looseversion`

### DIFF
--- a/custom/virt-minion/latest.Dockerfile
+++ b/custom/virt-minion/latest.Dockerfile
@@ -30,7 +30,9 @@ RUN dnf update -y && \
       PyYAML \
       urllib3 \
       chardet \
-      certifi
+      certifi \
+      looseversion \
+      packaging
 
 RUN echo 'listen_tls = 1'     >> /etc/libvirt/libvirtd.conf; \
     echo 'listen_tcp = 1'     >> /etc/libvirt/libvirtd.conf; \


### PR DESCRIPTION


Signed-off-by: Pedro Algarvio <palgarvio@vmware.com>