### PR TITLE
remove centos 7 form the packaging containers, it is unused

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ will be commited.
 
 ### [![Salt Packaging](https://github.com/saltstack/salt-ci-containers/actions/workflows/packaging-containers.yml/badge.svg)](https://github.com/saltstack/salt-ci-containers/actions/workflows/packaging-containers.yml)
 
-- packaging:centos-7 - `ghcr.io/saltstack/salt-ci-containers/packaging:centos-7`
 - packaging:centosstream-9 - `ghcr.io/saltstack/salt-ci-containers/packaging:centosstream-9`
 - packaging:debian-11 - `ghcr.io/saltstack/salt-ci-containers/packaging:debian-11`
 

--- a/containers.yml
+++ b/containers.yml
@@ -34,7 +34,6 @@ custom:
   Salt Packaging:
     name: packaging
     versions:
-      - centos-7
       - debian-11
       - centosstream-9
     exclude_platforms:

--- a/custom/packaging/README.md
+++ b/custom/packaging/README.md
@@ -1,5 +1,4 @@
 # [![Salt Packaging](https://github.com/saltstack/salt-ci-containers/actions/workflows/packaging-containers.yml/badge.svg)](https://github.com/saltstack/salt-ci-containers/actions/workflows/packaging-containers.yml)
 
-- packaging:centos-7 - `ghcr.io/saltstack/salt-ci-containers/packaging:centos-7`
 - packaging:centosstream-9 - `ghcr.io/saltstack/salt-ci-containers/packaging:centosstream-9`
 - packaging:debian-11 - `ghcr.io/saltstack/salt-ci-containers/packaging:debian-11`

--- a/custom/packaging/centos-7.Dockerfile
+++ b/custom/packaging/centos-7.Dockerfile
@@ -1,6 +1,0 @@
-FROM centos:7
-
-RUN yum update -y \
-  && yum -y install python3 python3-pip openssl git rpmdevtools rpmlint \
-    systemd-units libxcrypt-compat git gnupg2 jq createrepo rpm-sign \
-  && python3 -m pip install awscli


### PR DESCRIPTION
We will be pointing users of salt to this repo in documentation on how to build salt packages.  Removing this one to make it less cluttered and confusing since it is unused.