### PR TITLE
Debian 12 slim; add lsb-release to builddocs

### DIFF
--- a/custom/builddocs/latest.Dockerfile
+++ b/custom/builddocs/latest.Dockerfile
@@ -1,5 +1,5 @@
-FROM python:3.10-slim-bookworm
+FROM debian:12-slim
 
 RUN apt-get update \
-    && apt-get install -y build-essential git fontconfig inkscape rclone rsync make texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk poppler-utils python3-venv libcurl4-openssl-dev libssl-dev \
+    && apt-get install -y build-essential git fontconfig inkscape lsb-release rclone rsync make texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk poppler-utils libcurl4-openssl-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- Remove Python requirement, as `setup-python` makes Python available in GHA
- Add `lsb-release` package, which `setup-python` GHA requires