### PR TITLE
Add libffi-dev requirement to builddocs

### DIFF
--- a/custom/builddocs/latest.Dockerfile
+++ b/custom/builddocs/latest.Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.10-slim-bookworm
 
 RUN apt-get update \
-    && apt-get install -y build-essential git python3-venv fontconfig inkscape lsb-release rclone rsync make texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk poppler-utils libcurl4-openssl-dev libssl-dev \
+    && apt-get install -y build-essential git python3-venv fontconfig inkscape lsb-release rclone rsync make texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended texlive-xetex latexmk poppler-utils libcurl4-openssl-dev libssl-dev libffi-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Requires libffi-dev to build the latest docs from 3006.10+