### PR TITLE
Strip OpenSSL from base; bump salt to 3007.6

### DIFF
--- a/custom/testing/amazonlinux-2.Dockerfile
+++ b/custom/testing/amazonlinux-2.Dockerfile
@@ -15,15 +15,15 @@ RUN <<EOF
   fi
 
   yum update -y
-  yum install -y curl wget tar xz patchelf util-linux openssl-pkcs11
+  yum install -y curl wget tar xz patchelf util-linux
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/amazonlinux-2023.Dockerfile
+++ b/custom/testing/amazonlinux-2023.Dockerfile
@@ -15,16 +15,16 @@ RUN <<EOF
   fi
 
   yum update -y
-  yum install -y wget tar xz patchelf util-linux openssl openssl-pkcs11
+  yum install -y wget tar xz patchelf util-linux
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   # Python does not compile in a timely manner on amazon2023 and fedora40 arm64
   ./salt/salt-call --log-level=debug --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/debian-11.Dockerfile
+++ b/custom/testing/debian-11.Dockerfile
@@ -23,12 +23,12 @@ RUN <<EOF
   apt update -y
   apt install -y tar wget xz-utils vim-nox apt-utils
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/debian-12.Dockerfile
+++ b/custom/testing/debian-12.Dockerfile
@@ -22,13 +22,13 @@ RUN <<EOF
 
   apt update -y
   apt install -y tar wget xz-utils vim-nox apt-utils
-wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
 ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/fedora-42.Dockerfile
+++ b/custom/testing/fedora-42.Dockerfile
@@ -15,17 +15,17 @@ RUN <<EOF
   fi
 
   yum update -y
-  yum install -y curl wget tar xz patchelf openssl-pkcs11-sign-provider
+  yum install -y curl wget tar xz patchelf
 
   yum install -y make gcc libffi-devel
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --log-level=debug --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/photon-4.Dockerfile
+++ b/custom/testing/photon-4.Dockerfile
@@ -17,13 +17,13 @@ RUN <<EOF
   tdnf update -y
   tdnf install -y curl wget tar xz # patchelf
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/photon-5.Dockerfile
+++ b/custom/testing/photon-5.Dockerfile
@@ -17,13 +17,13 @@ RUN <<EOF
   tdnf update -y
   tdnf install -y curl wget tar xz  # patchelf
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/rockylinux-10.Dockerfile
+++ b/custom/testing/rockylinux-10.Dockerfile
@@ -14,15 +14,15 @@ RUN <<EOF
 
   yum update -y
   yum install -y epel-release
-  yum install -y wget tar xz patchelf openssl
+  yum install -y wget tar xz patchelf
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/rockylinux-8.Dockerfile
+++ b/custom/testing/rockylinux-8.Dockerfile
@@ -18,13 +18,13 @@ RUN <<EOF
   yum install -y epel-release
   yum install -y curl wget tar xz patchelf
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/rockylinux-9.Dockerfile
+++ b/custom/testing/rockylinux-9.Dockerfile
@@ -16,13 +16,13 @@ RUN <<EOF
   yum install -y epel-release
   yum install -y wget tar xz patchelf
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/ubuntu-20.04.Dockerfile
+++ b/custom/testing/ubuntu-20.04.Dockerfile
@@ -23,13 +23,13 @@ RUN <<EOF
   apt update -y
   apt install -y tar wget xz-utils vim-nox apt-utils
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/ubuntu-22.04.Dockerfile
+++ b/custom/testing/ubuntu-22.04.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG PROVISTION_SALT_VERSION 3007.5
+ARG PROVISTION_SALT_VERSION 3007.6
 
 COPY 01_nodoc /etc/dpkg/dpkg.cfg.d/01_nodoc
 COPY golden-pillar-tree golden-pillar-tree
@@ -25,13 +25,13 @@ RUN <<EOF
   apt update -y
   apt install -y tar wget xz-utils vim-nox apt-utils
 
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 

--- a/custom/testing/ubuntu-24.04.Dockerfile
+++ b/custom/testing/ubuntu-24.04.Dockerfile
@@ -22,13 +22,13 @@ RUN <<EOF
 
   apt update -y
   apt install -y tar wget xz-utils vim-nox apt-utils
-  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.5/salt-3007.5-onedir-linux-$ARCH.tar.xz
-  tar xf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/3007.6/salt-3007.6-onedir-linux-$ARCH.tar.xz
+  tar xf salt-3007.6-onedir-linux-$ARCH.tar.xz
 
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt
-  rm -rf salt-3007.5-onedir-linux-$ARCH.tar.xz
+  rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 


### PR DESCRIPTION
- Bump Salt to 3007.6
  - Latest relenv included with Salt will fallback to provided openssl when openssl providers are not discovered on the host system
- Since host level container image no longer requires openssl to make use of salt onedir tarball, stripping openssl explicit installs from the container images so that Salt can install openssl on an as-needed basis into the base images via state golden tree