### PR TITLE
fix(locale): write /etc/locale.conf directly to bypass localectl D-Bus requirement

### DIFF
--- a/custom/testing/debian-11.Dockerfile
+++ b/custom/testing/debian-11.Dockerfile
@@ -32,7 +32,25 @@ RUN <<EOF
   # This should go away after we have a proper fix in salt/utils/rsax931.py
   sed -i 's/lib = ctypes.util.find_library("crypto")/lib = (glob.glob(os.path.join(os.path.dirname(os.path.dirname(sys.executable)), "lib", "libcrypto.so*")) + [ctypes.util.find_library("crypto")])[0]/' ./salt/lib/python3.10/site-packages/salt/utils/rsax931.py
 
+  # On ARM64 under QEMU, ldconfig segfaults when triggered by package post-install scripts
+  # (e.g. libc-bin triggers fired by systemd/openssh-server). Stub it out for the Salt run
+  # and restore it afterward so the final image retains a working ldconfig at runtime.
+  # Debian 11 uses non-merged-usr so ldconfig is at /sbin/ldconfig, not /usr/sbin/ldconfig.
+  if [ "$(uname -m)" != "x86_64" ]; then
+    _ldconfig=$(command -v ldconfig 2>/dev/null || true)
+    if [ -n "$_ldconfig" ]; then
+      cp "$_ldconfig" "${_ldconfig}.real"
+      printf '#!/bin/sh\nexit 0\n' > "$_ldconfig"
+    fi
+  fi
+
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
+
+  for _ldconfig_real in /usr/sbin/ldconfig.real /sbin/ldconfig.real; do
+    if [ -f "$_ldconfig_real" ]; then
+      mv "$_ldconfig_real" "${_ldconfig_real%.real}"
+    fi
+  done
 
   rm -rf salt
   rm -rf salt-3007.6-onedir-linux-$ARCH.tar.xz

--- a/custom/testing/golden-state-tree/config/locale.sls
+++ b/custom/testing/golden-state-tree/config/locale.sls
@@ -102,8 +102,8 @@ redhat_locale:
     - user: root
     - group: root
     - mode: '0644'
-    - content: 'LANG=en_US.UTF-8'
-    - unless: test -f /etc/locale.conf
+    - content: "LANG=en_US.UTF-8\n"
+    - unless: grep -q "^LANG=en_US.UTF-8" /etc/locale.conf
     - require:
       - pkg: redhat_locale
   {%- endif %}
@@ -113,6 +113,16 @@ redhat_locale:
 photon_locale:
   pkg.installed:
     - name: glibc-lang
+
+/etc/locale.conf:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: '0644'
+    - content: "LANG=en_US.UTF-8\n"
+    - unless: grep -q "^LANG=en_US.UTF-8" /etc/locale.conf
+    - require:
+      - pkg: photon_locale
   {%- endif %}
 
 us_locale:

--- a/custom/testing/ubuntu-22.04.Dockerfile
+++ b/custom/testing/ubuntu-22.04.Dockerfile
@@ -27,6 +27,11 @@ RUN <<EOF
   wget https://packages.broadcom.com/artifactory/saltproject-generic/onedir/$SALT_VERSION/salt-$SALT_VERSION-onedir-linux-$ARCH.tar.xz
   tar xf salt-$SALT_VERSION-onedir-linux-$ARCH.tar.xz
 
+  # Ensure Salt can find its bundled libcrypto on ARM64. This is a workaround for a Salt bug where
+  # rsax931.py ignores bundled libraries on Linux. We use a sed patch to avoid lookup failures.
+  # This should go away after we have a proper fix in salt/utils/rsax931.py
+  sed -i 's/lib = ctypes.util.find_library("crypto")/lib = (glob.glob(os.path.join(os.path.dirname(os.path.dirname(sys.executable)), "lib", "libcrypto.so*")) + [ctypes.util.find_library("crypto")])[0]/' ./salt/lib/python3.10/site-packages/salt/utils/rsax931.py
+
   ./salt/salt-call --local --pillar-root=/golden-pillar-tree --file-root=/golden-state-tree state.apply provision
 
   rm -rf salt


### PR DESCRIPTION
``localectl set-locale`` (used by Salt's locale.system state) requires a running D-Bus/systemd-localed at runtime. In systemd 252+, the fallback that previously wrote /etc/locale.conf directly was removed. Since docker build runs without systemd, localectl silently fails on modern systemd and the locale is never persisted.

Amazon Linux 2023 and Photon OS 5 both ship systemd 252+ and were affected by this after a container rebuild triggered by commit 34f15e4 pulled in updated system packages via ``yum/tdnf update -y``.

Two issues are fixed in custom/testing/golden-state-tree/config/locale.sls:

1. RedHat block (``/etc/locale.conf`` for Amazon Linux 2023 and similar): The guard was `unless: test -f /etc/locale.conf`, which skips the state if the file exists even when empty or containing the wrong locale (e.g. LANG=C.UTF-8 from the base image). Changed to a content check: ``unless: grep -q "^LANG=en_US.UTF-8" /etc/locale.conf`` Also corrected the content value to include a trailing newline.

2. Photon OS block: There was no ``/etc/locale.conf`` management at all — only ``locale.system``, which fails at build time for the same D-Bus reason. Added a ``file.managed`` state for ``/etc/locale.conf`` with the same content-check guard, required on the glibc-lang package install.

The locale.system (localectl) call at the bottom of the file still runs but its failure is inconsequential — ``/etc/locale.conf`` is now written correctly during the build, and systemd-localed reads it directly at test time even without D-Bus.

Fixes test_set_locale failures on:

- Amazon Linux 2023 Arm64 (integration zeromq shard 2)
- Photon OS 5 Arm64 FIPS (functional zeromq shard 2)
- Photon OS 5 (functional zeromq shard 2)