### PR TITLE
fix(ubuntu-22.04): retry ldconfig on arm64 to tolerate QEMU segfaults

### DIFF
--- a/custom/testing/ubuntu-22.04.Dockerfile
+++ b/custom/testing/ubuntu-22.04.Dockerfile
@@ -48,10 +48,15 @@ RUN <<EOF
   rm -rf golden-pillar-tree
   rm -rf golden-state-tree
 
-  # Restore ldconfig and rebuild the library cache
+  # Restore ldconfig and rebuild the library cache. ldconfig itself can
+  # segfault intermittently under QEMU arm64 emulation, so retry a few
+  # times before giving up.
   if [ "$ARCH" = "arm64" ]; then
     mv /sbin/ldconfig.orig /sbin/ldconfig
-    /sbin/ldconfig
+    for i in 1 2 3 4 5; do
+      /sbin/ldconfig && break
+      echo "ldconfig attempt $i failed, retrying..."
+    done
   fi
 
   rm -rf /var/log/salt


### PR DESCRIPTION
The final ldconfig call that rebuilds the library cache can itself segfault intermittently under QEMU arm64 emulation — this is why the same commit passed on the PR run but failed once merged. Retry up to 5 times before giving up instead of failing the build outright.